### PR TITLE
Changed line 35: testing Packages/ for existence 

### DIFF
--- a/zsh-scripts/bin/setup-sync-sublime-over-dropbox.sh
+++ b/zsh-scripts/bin/setup-sync-sublime-over-dropbox.sh
@@ -32,8 +32,8 @@ else
 fi
 
 # Check that settings really exist on this computer
-if [ ! -e "$SOURCE/Packages/" ]; then
-        echo "Could not find $SOURCE/Settings/"
+if [ ! -e "$SOURCE/Packages" ]; then
+        echo "Could not find $SOURCE/Packages/"
         exit 1
 fi
 


### PR DESCRIPTION
Minor change.

Removed the trailing "/"  (line 35) so that, if the path to
$SOURCE/Packages points to a symlink, the script doesn't
exit until testing for it later. testing "[ -e $SOURCE/Packages/ ]"
would return false if not a folder.

Functionality-wise the script was still working though.
